### PR TITLE
fix(dependencies): remediate 27 Dependabot alerts

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,78 @@
+name: Quality
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: quality-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  DATABASE_URL: sqlite+aiosqlite:///./quality-ci.sqlite3
+
+jobs:
+  quality:
+    name: Python 3.14 quality
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.14.7'
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt ruff==0.15.22 pip-audit==2.10.1
+          python -m pip check
+
+      - name: Audit dependencies
+        run: >-
+          python -m pip_audit
+          --requirement requirements.txt
+          --strict
+          --progress-spinner off
+          --ignore-vuln PYSEC-2026-1325
+
+      - name: Ruff changed Python files
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            lint_base="origin/$BASE_REF"
+          elif [[ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]] \
+            && git cat-file -e "$BEFORE_SHA^{commit}"; then
+            lint_base="$BEFORE_SHA"
+          else
+            lint_base="$(git rev-list --max-parents=0 HEAD)"
+          fi
+
+          mapfile -d '' python_files < <(
+            git diff --name-only -z --diff-filter=ACMR "$lint_base"...HEAD -- '*.py'
+          )
+          if ((${#python_files[@]})); then
+            ruff check "${python_files[@]}"
+          else
+            echo "No changed Python files."
+          fi
+
+      - name: Migrate fresh SQLite database
+        run: |
+          python -m alembic upgrade head
+          python -m alembic current
+
+      - name: Test
+        run: python -m pytest tests/ -q

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -50,6 +50,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
           BEFORE_SHA: ${{ github.event.before }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
             lint_base="origin/$BASE_REF"
@@ -57,7 +58,7 @@ jobs:
             && git cat-file -e "$BEFORE_SHA^{commit}"; then
             lint_base="$BEFORE_SHA"
           else
-            lint_base="$(git rev-list --max-parents=0 HEAD)"
+            lint_base="origin/$DEFAULT_BRANCH"
           fi
 
           mapfile -d '' python_files < <(

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -51,14 +51,19 @@ python-engineio 4.13.5 和 python-socketio 5.16.4。NiceGUI 3.16.0 与 FastAPI
 
 ## 5. 本地复验
 
-在 Python 3.14.7 新建的隔离环境中执行：
+在 Python 3.14.7 新建的隔离环境中执行。迁移复验必须显式指向一次性 SQLite，
+避免读取 `.env` 后修改应用数据库或真实集成数据库；临时目录在当前 shell 退出时清理：
 
 ```bash
 python -m pip install -r requirements.txt ruff==0.15.22 pip-audit==2.10.1
 python -m pip check
 python -m pip_audit -r requirements.txt --strict --ignore-vuln PYSEC-2026-1325
 ruff check tests/test_dependency_security_floor.py
-python -m alembic upgrade head
+quality_db_dir="$(mktemp -d)"
+trap 'rm -rf -- "$quality_db_dir"' EXIT
+quality_database_url="sqlite+aiosqlite:///$quality_db_dir/quality.sqlite3"
+DATABASE_URL="$quality_database_url" python -m alembic upgrade head
+DATABASE_URL="$quality_database_url" python -m alembic current
 python -m pytest tests/ -q
 ```
 

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -1,0 +1,75 @@
+# Python 依赖安全基线
+
+> 快照日期：2026-08-23。本文记录默认分支依赖策略、Dependabot #11–#37
+> 的修复边界和质量门禁。后续升级必须重新解析依赖并回读 GitHub 告警。
+
+## 1. 27 项 Dependabot 告警
+
+GitHub 当前将 27 项开放告警归因到已经从仓库删除、但仍存在于依赖图快照中的
+`uv.lock`。默认分支原有的 `requirements.txt` 下限同样不安全，因此不能把这些告警
+作为误报直接关闭。
+
+| 依赖族 | 告警 | 安全下限 |
+|---|---:|---:|
+| `aiohttp` | #11–#19、#32–#34（12 项） | `3.14.3` |
+| `cryptography` | #20、#35–#37（4 项） | `50.0.0` |
+| `starlette` | #21、#22、#27、#28（4 项） | `1.3.1` |
+| `python-multipart` | #23–#26（4 项） | `0.0.31` |
+| `python-engineio` | #29、#30（2 项） | `4.13.2` |
+| `python-socketio` | #31（1 项） | `5.16.2` |
+
+`requirements.txt` 采用不低于上表、并已联合验证的版本：aiohttp 3.14.3、
+cryptography 50.0.0、Starlette 1.6.0、python-multipart 0.0.32、
+python-engineio 4.13.5 和 python-socketio 5.16.4。NiceGUI 3.16.0 与 FastAPI
+0.141.1 一并升级，避免在 Web 框架兼容面上单独强推传递依赖。
+
+## 2. RED 与质量门禁
+
+- Issue：[#49](https://github.com/ywyz/kindergartenManager/issues/49)。
+- 稳定 RED：`ab1a621625fabc43e42aadbda1e189d2a2f0185e`，修复前连续三次得到
+  同一组六族失败。
+- `tests/test_dependency_security_floor.py` 固定最低安全版本，避免未来解析回落。
+- `.github/workflows/quality.yml` 在常规 push 和 pull request 上使用 Python 3.14.7，
+  执行安装、`pip check`、`pip-audit`、变更 Python 文件 Ruff、全新 SQLite 迁移和全量 pytest。
+- `main@225fe13` 已有 47 条 Ruff 历史告警，本安全 PR 不跨范围机械修改业务代码；门禁对
+  每次 push/PR 的变更 Python 文件执行严格 Ruff，阻止新增债务，同时保留全仓测试覆盖。
+
+## 3. 约束策略
+
+- 项目当前使用 `requirements.txt` 和 `>=` 安全下限，安装时解析当时兼容的较新版本。
+- 直接声明传递依赖是为了防止解析回落，不表示应用直接调用这些包。
+- 当前没有带哈希的锁文件，因此验收必须记录实际解析版本，不能只报告声明下限。
+- 本地通过不等于 GitHub 告警已关闭。只有变更进入默认分支且依赖图重新计算后，
+  才能回读 27 项告警的最终 `fixed` 状态。
+
+## 4. 已知无修复例外
+
+`python-jose` 传递依赖 `ecdsa==0.19.2` 仍对应 `PYSEC-2026-1325`、
+`GHSA-wj6h-64fc-37mp` / `CVE-2024-23342`。当前没有上游修复版本；消除该风险需要
+独立评估并替换 JWT 库，不属于 #49 的 27 项 Dependabot 修复范围。质量门禁只对这个
+明确编号使用 `--ignore-vuln`，其他可检测漏洞仍会使构建失败。
+
+## 5. 本地复验
+
+在 Python 3.14.7 新建的隔离环境中执行：
+
+```bash
+python -m pip install -r requirements.txt ruff==0.15.22 pip-audit==2.10.1
+python -m pip check
+python -m pip_audit -r requirements.txt --strict --ignore-vuln PYSEC-2026-1325
+ruff check tests/test_dependency_security_floor.py
+python -m alembic upgrade head
+python -m pytest tests/ -q
+```
+
+2026-08-23 的 #49 GREEN 复验记录：
+
+- 基线：`main@225fe139`；稳定 RED：`ab1a621625fabc43e42aadbda1e189d2a2f0185e`。
+- 环境：Python 3.14.7、uv 0.12.5；隔离环境解析并安装 103 个包，`pip check`
+  返回 `No broken requirements found.`。
+- 实际关键版本：NiceGUI 3.16.0、FastAPI 0.141.1、aiohttp 3.14.3、
+  cryptography 50.0.0、Starlette 1.6.0、python-multipart 0.0.32、
+  python-engineio 4.13.5、python-socketio 5.16.4。
+- `pip-audit 2.10.1`：`No known vulnerabilities found, 1 ignored`；唯一忽略项为
+  第 4 节明确记录的 `PYSEC-2026-1325`。
+- 全新 SQLite 从空库迁移到 `a6c4d8e2f9b1 (head)`；全量 pytest：`530 passed`。

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@
 # 安装命令：pip install -r requirements.txt
 
 # Web 框架
-nicegui>=2.0.0
-fastapi>=0.115.0
+nicegui>=3.16.0
+fastapi>=0.141.1
 uvicorn>=0.30.0
 
 # 数据库
@@ -17,8 +17,8 @@ pydantic-settings>=2.0.0
 
 # 鉴权与加密
 argon2-cffi>=23.1.0
-python-jose[cryptography]>=3.3.0
-cryptography>=44.0.1   # 安全下限：修复 CVE-2024-26130 / CVE-2024-12797 等（构建时解析到最新）
+python-jose[cryptography]>=3.3.0  # ecdsa 无修复公告例外见 docs/DEPENDENCIES.md
+cryptography>=50.0.0   # Dependabot #20/#35–#37
 
 # HTTP 客户端
 httpx>=0.27.0
@@ -38,12 +38,14 @@ apscheduler>=3.10.0
 # 日志
 python-json-logger>=2.0.0
 
-# ── 传递依赖安全下限（修复 Dependabot 告警） ──────────────────────────────
+# ── 直接/传递依赖安全下限（Dependabot，2026-08-23） ─────────────────────────
 # 以下包由 nicegui / httpx 等间接引入；显式声明安全下限以提升依赖图最小解析版本。
-# 构建时仍会解析到各自最新版本；精确补丁版本以对应 GitHub 安全公告为准。
-aiohttp>=3.12.14          # 经 nicegui 引入；修复 ReDoS/请求走私等多个 CVE
-python-multipart>=0.0.18  # 经 nicegui/starlette 引入；修复 CVE-2024-53981(DoS)
-starlette>=0.47.2         # 经 nicegui/fastapi 引入；修复 CVE-2024-47874 / CVE-2025-54121
+# 构建时仍会解析到兼容的新版本；基线和告警映射见 docs/DEPENDENCIES.md。
+aiohttp>=3.14.3           # Dependabot #11–#19/#32–#34
+python-socketio>=5.16.4  # Dependabot #31；NiceGUI 实时通信链
+python-engineio>=4.13.5  # Dependabot #29/#30；python-socketio 传递链
+python-multipart>=0.0.32 # Dependabot #23–#26；FastAPI/NiceGUI 表单解析
+starlette>=1.6.0         # Dependabot #21/#22/#27/#28；与 FastAPI 联合解析
 lxml>=5.3.0               # 经 nicegui 引入；修复历史 XML 解析类 CVE
 urllib3>=2.5.0            # 传递依赖；修复 CVE-2025-50181 / CVE-2025-50182
 idna>=3.7                 # 经 httpx 引入；修复 CVE-2024-3651(DoS)

--- a/tests/test_dependency_security_floor.py
+++ b/tests/test_dependency_security_floor.py
@@ -1,0 +1,51 @@
+"""Regression guard for the dependency floors frozen in GitHub Issue #49."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REQUIREMENTS_PATH = Path(__file__).parents[1] / "requirements.txt"
+REQUIRED_SECURITY_FLOORS = {
+    "aiohttp": "3.14.3",
+    "cryptography": "50.0.0",
+    "python-engineio": "4.13.2",
+    "python-multipart": "0.0.31",
+    "python-socketio": "5.16.2",
+    "starlette": "1.3.1",
+}
+REQUIREMENT_PATTERN = re.compile(
+    r"^(?P<name>[A-Za-z0-9_.-]+)(?:\[[^]]+\])?\s*>=\s*(?P<version>[0-9]+(?:\.[0-9]+)*)"
+)
+
+
+def _version_tuple(version: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in version.split("."))
+
+
+def _minimum_versions() -> dict[str, str]:
+    minimums: dict[str, str] = {}
+    for raw_line in REQUIREMENTS_PATH.read_text(encoding="utf-8").splitlines():
+        line = raw_line.split("#", maxsplit=1)[0].strip()
+        match = REQUIREMENT_PATTERN.match(line)
+        if match:
+            minimums[match.group("name").lower()] = match.group("version")
+    return minimums
+
+
+def test_requirements_cover_frozen_dependabot_security_floors() -> None:
+    """All six vulnerable families must resolve no lower than their patched release."""
+    minimums = _minimum_versions()
+    failures = []
+
+    for package, required_floor in REQUIRED_SECURITY_FLOORS.items():
+        actual_floor = minimums.get(package)
+        if actual_floor is None:
+            failures.append(f"{package}: missing (need >= {required_floor})")
+        elif _version_tuple(actual_floor) < _version_tuple(required_floor):
+            failures.append(
+                f"{package}: found >= {actual_floor} (need >= {required_floor})"
+            )
+
+    assert not failures, "Unsafe dependency floors:\n" + "\n".join(failures)


### PR DESCRIPTION
## Summary

- raise the six vulnerable dependency families to patched floors and upgrade the jointly compatible NiceGUI/FastAPI surface
- freeze Issue #49 with a stable requirements-floor RED at `ab1a621625fabc43e42aadbda1e189d2a2f0185e`
- add a Python 3.14.7 push/PR quality workflow covering install, `pip check`, `pip-audit`, changed-file Ruff, fresh SQLite migration, and full pytest
- document the dependency strategy, actual resolved versions, alert mapping, and the single no-fix `python-jose -> ecdsa` exception

Closes #49

## Verification

- isolated Python 3.14.7 environment; 103 packages resolved
- `pip check`: no broken requirements
- `pip-audit 2.10.1`: no known vulnerabilities found, 1 explicitly documented no-fix advisory ignored (`PYSEC-2026-1325`)
- fresh SQLite migration: `a6c4d8e2f9b1 (head)`
- full pytest: `530 passed`
- dependency security regression: `1 passed`
- actionlint v1.7.10: passed
- changed-file Ruff 0.15.22: passed

## Graph/document decision

`docs/DEPENDENCIES.md` is added because the security and exception policy needs a durable source of truth. No Graphify artifact is committed: `main` has no tracked Graphify/codebase-memory baseline and this PR changes no application call graph; importing another development branch graph would create a misleading, unrelated diff. The workspace codebase-memory index was refreshed and the new regression test node was read back successfully.

## Merge boundary

Do not auto-merge. The 27 GitHub alerts remain external RED until this PR reaches the default branch and GitHub recomputes its dependency graph.