### PR TITLE
fix(auth): remove vulnerable ecdsa dependency

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -42,7 +42,6 @@ jobs:
           --requirement requirements.txt
           --strict
           --progress-spinner off
-          --ignore-vuln PYSEC-2026-1325
 
       - name: Ruff changed Python files
         shell: bash

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 | 语言 | Python 3.12+（开发环境 3.14） |
 | 前后端 | NiceGUI（底层 FastAPI / Starlette） |
 | 数据库 | MySQL 8（async：SQLAlchemy 2 + aiomysql）；迁移：Alembic |
-| 鉴权 | JWT（python-jose）+ Argon2（argon2-cffi）+ RBAC |
+| 鉴权 | JWT（PyJWT）+ Argon2（argon2-cffi）+ RBAC |
 | 加密 | Fernet（cryptography）—— AI Key 入库加密 |
 | AI | OpenAI 兼容 Chat Completions（httpx + tenacity 重试） |
 | 文档导出 | python-docx |

--- a/app/auth/jwt.py
+++ b/app/auth/jwt.py
@@ -1,7 +1,8 @@
 """JWT access token 生成与解码工具。"""
 from datetime import datetime, timedelta, timezone
 
-from jose import JWTError, jwt
+import jwt
+from jwt.exceptions import PyJWTError
 
 from app.core.config import settings
 from app.core.exceptions import AuthError
@@ -48,5 +49,5 @@ def decode_access_token(token: str) -> dict:
     try:
         payload = jwt.decode(token, settings.JWT_SECRET, algorithms=[_ALGORITHM])
         return payload
-    except JWTError as exc:
+    except PyJWTError as exc:
         raise AuthError("token 无效或已过期") from exc

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -116,5 +116,5 @@ python -m pytest tests/ -q
   已从精确锁中移除，替换为 `PyJWT 2.13.0`；HS256 token 接口与字段保持不变。
 - `uv lock --check`、`uv pip check` 与 Ruff 均通过；无忽略项执行 pip-audit：
   `No known vulnerabilities found`。
-- 全新 SQLite 从空库迁移到 `a6c4d8e2f9b1 (head)`；目标测试 `7 passed`，全量 pytest：
-  `531 passed`。
+- 全新 SQLite 从空库迁移到 `a6c4d8e2f9b1 (head)`；目标测试 `8 passed`（含旧
+  `python-jose` HS256 token 跨库兼容），全量 pytest：`532 passed`。

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -1,14 +1,18 @@
 # Python 依赖安全基线
 
-> 快照日期：2026-08-23。本文记录默认分支依赖策略、Dependabot #11–#37
+> 快照日期：2026-08-23。本文记录默认分支依赖策略、Dependabot #11–#38
 > 的修复边界和质量门禁。后续升级必须重新解析依赖并回读 GitHub 告警。
 
-## 1. 27 项 Dependabot 告警
+## 1. 28 项 Dependabot 告警
 
 GitHub 将 27 项开放告警归因到历史 `uv.lock` 中的漏洞版本。仅删除锁文件并刷新
 `requirements.txt` 后，旧锁快照仍保留在依赖图中；本次恢复 `pyproject.toml` 并重新
 生成安全的 `uv.lock`，用于让依赖图以新快照覆盖旧版本。告警是否转为 `fixed` 仍须在
 变更进入默认分支、依赖图完成刷新后回读，不能作为误报直接关闭。
+
+#11–#37 已在 `main@863a238` 的新锁快照中转为 `fixed`。该锁随后暴露了此前未被
+依赖图追踪的 `ecdsa` 告警 #38；它没有上游修复版本，必须移除依赖链，不能通过升级或
+dismiss 闭环。
 
 | 依赖族 | 告警 | 安全下限 |
 |---|---:|---:|
@@ -18,6 +22,7 @@ GitHub 将 27 项开放告警归因到历史 `uv.lock` 中的漏洞版本。仅�
 | `python-multipart` | #23–#26（4 项） | `0.0.31` |
 | `python-engineio` | #29、#30（2 项） | `4.13.2` |
 | `python-socketio` | #31（1 项） | `5.16.2` |
+| `ecdsa` | #38（1 项） | 无修复版本；移除 `python-jose` 依赖链 |
 
 `requirements.txt` 采用不低于上表、并已联合验证的版本：aiohttp 3.14.3、
 cryptography 50.0.0、Starlette 1.6.0、python-multipart 0.0.32、
@@ -29,7 +34,10 @@ python-engineio 4.13.5 和 python-socketio 5.16.4。NiceGUI 3.16.0 与 FastAPI
 - Issue：[#49](https://github.com/ywyz/kindergartenManager/issues/49)。
 - 稳定 RED：`ab1a621625fabc43e42aadbda1e189d2a2f0185e`，修复前连续三次得到
   同一组六族失败。
-- `tests/test_dependency_security_floor.py` 固定最低安全版本，避免未来解析回落。
+- #38 稳定 RED：`4c9bd2c2a8c80d459411a451988da11b8c592aed`，连续三次得到
+  `PyJWT` 安全下限缺失、锁中存在 `ecdsa` / `python-jose` 的同一失败。
+- `tests/test_dependency_security_floor.py` 固定最低安全版本，并禁止精确锁重新引入
+  无修复的 `ecdsa` / `python-jose` 运行时依赖链。
 - `.github/workflows/quality.yml` 在常规 push 和 pull request 上使用 Python 3.14.7，
   执行安装、`pip check`、`pip-audit`、变更 Python 文件 Ruff、全新 SQLite 迁移和全量 pytest。
 - `main@225fe13` 已有 47 条 Ruff 历史告警，本安全 PR 不跨范围机械修改业务代码；门禁对
@@ -45,14 +53,15 @@ python-engineio 4.13.5 和 python-socketio 5.16.4。NiceGUI 3.16.0 与 FastAPI
 - 新版本发布不会自动使锁文件过期；升级时必须显式执行 `uv lock --upgrade`，并提交
   `pyproject.toml` 与 `uv.lock` 的一致变更。
 - 本地通过不等于 GitHub 告警已关闭。只有变更进入默认分支且依赖图重新计算后，
-  才能回读 27 项告警的最终 `fixed` 状态。
+  才能回读告警的最终 `fixed` 状态。
 
-## 4. 已知无修复例外
+## 4. 无修复依赖处理
 
-`python-jose` 传递依赖 `ecdsa==0.19.2` 仍对应 `PYSEC-2026-1325`、
-`GHSA-wj6h-64fc-37mp` / `CVE-2024-23342`。当前没有上游修复版本；消除该风险需要
-独立评估并替换 JWT 库，不属于 #49 的 27 项 Dependabot 修复范围。质量门禁只对这个
-明确编号使用 `--ignore-vuln`，其他可检测漏洞仍会使构建失败。
+`python-jose` 传递依赖 `ecdsa==0.19.2` 对应 `PYSEC-2026-1325`、
+`GHSA-wj6h-64fc-37mp` / `CVE-2024-23342`，且没有上游修复版本。应用只使用 HS256，
+但保留未使用的漏洞包仍不是可接受闭环，因此以 `PyJWT>=2.13.0` 替换 `python-jose`，
+重新生成的锁文件不得包含 `ecdsa` 或 `python-jose`。Quality 不再保留该漏洞的
+`pip-audit` 忽略项；完成状态以默认分支依赖图将 #38 回读为 `fixed` 为准。
 
 ## 5. 本地复验
 
@@ -65,8 +74,8 @@ uv sync --locked --all-groups
 uv pip check
 python -m pip install -r requirements.txt ruff==0.15.22 pip-audit==2.10.1
 python -m pip check
-python -m pip_audit -r requirements.txt --strict --ignore-vuln PYSEC-2026-1325
-ruff check tests/test_dependency_security_floor.py
+python -m pip_audit -r requirements.txt --strict
+ruff check app/auth/jwt.py tests/test_jwt.py tests/test_dependency_security_floor.py
 quality_db_dir="$(mktemp -d)"
 trap 'rm -rf -- "$quality_db_dir"' EXIT
 quality_database_url="sqlite+aiosqlite:///$quality_db_dir/quality.sqlite3"
@@ -97,3 +106,15 @@ python -m pytest tests/ -q
 - 对已安装锁定环境执行 pip-audit：`No known vulnerabilities found, 1 ignored`；唯一忽略项
   仍为第 4 节记录的 `PYSEC-2026-1325`。
 - 全新 SQLite 从空库迁移到 `a6c4d8e2f9b1 (head)`；全量 pytest：`530 passed`。
+
+2026-08-23 的 #38 GREEN 复验记录：
+
+- 基线：`main@863a2388c2a828078e85c30d5943faf16650f1bb`；稳定 RED：
+  `4c9bd2c2a8c80d459411a451988da11b8c592aed`。
+- 环境：Python 3.14.7、uv 0.11.30；锁文件解析 78 个包，隔离环境安装 75 个包。
+- `python-jose 3.5.0`、`ecdsa 0.19.2`、`rsa 4.9.1`、`pyasn1 0.6.4` 和 `six 1.17.0`
+  已从精确锁中移除，替换为 `PyJWT 2.13.0`；HS256 token 接口与字段保持不变。
+- `uv lock --check`、`uv pip check` 与 Ruff 均通过；无忽略项执行 pip-audit：
+  `No known vulnerabilities found`。
+- 全新 SQLite 从空库迁移到 `a6c4d8e2f9b1 (head)`；目标测试 `7 passed`，全量 pytest：
+  `531 passed`。

--- a/memory-bank/architecture.md
+++ b/memory-bank/architecture.md
@@ -101,7 +101,7 @@
 | `app/core/models/semester.py` | SemesterConfig ORM 模型 |
 | `app/core/models/class_config.py` | ClassConfig ORM 模型 |
 | `app/auth/password.py` | Argon2 密码哈希与验证（passlib） |
-| `app/auth/jwt.py` | JWT 生成/验证（python-jose HS256），payload 含 sub/tenant_id/role/exp |
+| `app/auth/jwt.py` | JWT 生成/验证（PyJWT HS256），payload 含 sub/tenant_id/role/exp |
 | `app/service/auth_service.py` | 登录逻辑（查用户→验密码→签 JWT）；修改密码 |
 | `app/service/date_service.py` | 纯函数：`get_week_number`、`get_weekday_cn`、`is_workday`、`is_within_semester` |
 | `app/repository/user_repository.py` | 按用户名/ID 查询用户；更新密码 |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "alembic",
     "pydantic-settings",
     "argon2-cffi",
-    "python-jose[cryptography]",
+    "PyJWT",
     "cryptography",
     "httpx",
     "tenacity",

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pydantic-settings>=2.0.0
 
 # 鉴权与加密
 argon2-cffi>=23.1.0
-python-jose[cryptography]>=3.3.0  # ecdsa 无修复公告例外见 docs/DEPENDENCIES.md
+PyJWT>=2.13.0         # Dependabot #38；替代含未修复 ecdsa 的 python-jose
 cryptography>=50.0.0   # Dependabot #20/#35–#37
 
 # HTTP 客户端

--- a/tests/test_dependency_security_floor.py
+++ b/tests/test_dependency_security_floor.py
@@ -3,16 +3,19 @@
 from __future__ import annotations
 
 import re
+import tomllib
 from pathlib import Path
 
 
 REQUIREMENTS_PATH = Path(__file__).parents[1] / "requirements.txt"
+UV_LOCK_PATH = Path(__file__).parents[1] / "uv.lock"
 REQUIRED_SECURITY_FLOORS = {
     "aiohttp": "3.14.3",
     "cryptography": "50.0.0",
     "python-engineio": "4.13.2",
     "python-multipart": "0.0.31",
     "python-socketio": "5.16.2",
+    "pyjwt": "2.13.0",
     "starlette": "1.3.1",
 }
 REQUIREMENT_PATTERN = re.compile(
@@ -35,7 +38,7 @@ def _minimum_versions() -> dict[str, str]:
 
 
 def test_requirements_cover_frozen_dependabot_security_floors() -> None:
-    """All six vulnerable families must resolve no lower than their patched release."""
+    """Vulnerable families must resolve no lower than their patched release."""
     minimums = _minimum_versions()
     failures = []
 
@@ -49,3 +52,18 @@ def test_requirements_cover_frozen_dependabot_security_floors() -> None:
             )
 
     assert not failures, "Unsafe dependency floors:\n" + "\n".join(failures)
+
+
+def test_lock_excludes_unpatched_python_ecdsa_runtime_dependency() -> None:
+    """The exact runtime graph must not contain the unpatched python-ecdsa chain."""
+    lock_data = tomllib.loads(UV_LOCK_PATH.read_text(encoding="utf-8"))
+    locked_names = {package["name"].lower() for package in lock_data["package"]}
+    prohibited = sorted({"ecdsa", "python-jose"} & locked_names)
+
+    failures = []
+    if prohibited:
+        failures.append("prohibited locked packages: " + ", ".join(prohibited))
+    if "pyjwt" not in locked_names:
+        failures.append("replacement package missing: pyjwt")
+
+    assert not failures, "Unsafe JWT dependency graph:\n" + "\n".join(failures)

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -9,6 +9,15 @@ from app.core.config import settings
 from app.core.exceptions import AuthError
 
 
+LEGACY_PYTHON_JOSE_SECRET = "compatibility-test-secret-at-least-32-bytes"
+LEGACY_PYTHON_JOSE_TOKEN = (
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+    "eyJzdWIiOiI0MiIsInRlbmFudF9pZCI6MSwicm9sZSI6InRlYWNoZXIiLCJ1c2VybmFtZSI6"
+    "ImxlZ2FjeSIsImRpc3BsYXlfbmFtZSI6bnVsbCwiZXhwIjo0MTAyNDQ0ODAwfQ."
+    "lqEFVPZ6V8XUVI135aAUQ0t-5hRORmqof2cacThLuTs"
+)
+
+
 def test_create_and_decode_returns_correct_fields():
     """正常 token 可成功解码并取回 user_id、tenant_id、role。"""
     token = create_access_token(user_id=42, tenant_id=1, role="teacher")
@@ -17,6 +26,22 @@ def test_create_and_decode_returns_correct_fields():
     assert payload["sub"] == "42"
     assert payload["tenant_id"] == 1
     assert payload["role"] == "teacher"
+
+
+def test_legacy_python_jose_hs256_token_remains_valid(monkeypatch):
+    """切换 JWT 库后，升级前签发且未过期的 token 仍可继续使用。"""
+    monkeypatch.setattr(settings, "JWT_SECRET", LEGACY_PYTHON_JOSE_SECRET)
+
+    payload = decode_access_token(LEGACY_PYTHON_JOSE_TOKEN)
+
+    assert payload == {
+        "sub": "42",
+        "tenant_id": 1,
+        "role": "teacher",
+        "username": "legacy",
+        "display_name": None,
+        "exp": 4102444800,
+    }
 
 
 def test_tampered_signature_raises_auth_error():

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -2,7 +2,7 @@
 from datetime import datetime, timedelta, timezone
 
 import pytest
-from jose import jwt
+import jwt
 
 from app.auth.jwt import _ALGORITHM, create_access_token, decode_access_token
 from app.core.config import settings
@@ -36,7 +36,11 @@ def test_wrong_secret_raises_auth_error():
         "role": "teacher",
         "exp": datetime.now(tz=timezone.utc) + timedelta(minutes=60),
     }
-    bad_token = jwt.encode(payload, "wrong-secret", algorithm=_ALGORITHM)
+    bad_token = jwt.encode(
+        payload,
+        "wrong-secret-that-is-at-least-32-bytes-long",
+        algorithm=_ALGORITHM,
+    )
     with pytest.raises(AuthError):
         decode_access_token(bad_token)
 

--- a/uv.lock
+++ b/uv.lock
@@ -463,18 +463,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ecdsa"
-version = "0.19.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/25/ca/8de7744cb3bc966c85430ca2d0fcaeea872507c6a4cf6e007f7fe269ed9d/ecdsa-0.19.2.tar.gz", hash = "sha256:62635b0ac1ca2e027f82122b5b81cb706edc38cd91c63dda28e4f3455a2bf930", size = 202432, upload-time = "2026-03-26T09:58:17.675Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/79/119091c98e2bf49e24ed9f3ae69f816d715d2904aefa6a2baa039a2ba0b0/ecdsa-0.19.2-py2.py3-none-any.whl", hash = "sha256:840f5dc5e375c68f36c1a7a5b9caad28f95daa65185c9253c0c08dd952bb7399", size = 150818, upload-time = "2026-03-26T09:58:15.808Z" },
-]
-
-[[package]]
 name = "fastapi"
 version = "0.141.1"
 source = { registry = "https://pypi.org/simple" }
@@ -785,10 +773,10 @@ dependencies = [
     { name = "nicegui" },
     { name = "pillow" },
     { name = "pydantic-settings" },
+    { name = "pyjwt" },
     { name = "pymysql" },
     { name = "python-docx" },
     { name = "python-engineio" },
-    { name = "python-jose", extra = ["cryptography"] },
     { name = "python-json-logger" },
     { name = "python-multipart" },
     { name = "python-socketio" },
@@ -821,10 +809,10 @@ requires-dist = [
     { name = "nicegui" },
     { name = "pillow" },
     { name = "pydantic-settings" },
+    { name = "pyjwt" },
     { name = "pymysql" },
     { name = "python-docx" },
     { name = "python-engineio" },
-    { name = "python-jose", extras = ["cryptography"] },
     { name = "python-json-logger" },
     { name = "python-multipart" },
     { name = "python-socketio" },
@@ -1406,15 +1394,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyasn1"
-version = "0.6.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
-]
-
-[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1537,6 +1516,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[[package]]
 name = "pymysql"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1606,25 +1594,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/d8/65cc479ab697a2e7fdee83a9bd8a06b61ec68bf763a58a302cf161bf38bb/python_engineio-4.13.5.tar.gz", hash = "sha256:b5764d62243e3ffbc4c76dda3d7897c329dc52294c80c27105f9faa054e76897", size = 80035, upload-time = "2026-08-12T22:52:23.78Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6b/01/f804208061b504894546fddc479f6075e0f00dfe88cb1703dafaa8c3c67e/python_engineio-4.13.5-py3-none-any.whl", hash = "sha256:05c9f4951d242ad33d613b4245299562e5f64e4199f00e5390f9888505831704", size = 59963, upload-time = "2026-08-12T22:52:22.5Z" },
-]
-
-[[package]]
-name = "python-jose"
-version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ecdsa" },
-    { name = "pyasn1" },
-    { name = "rsa" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/77/3a1c9039db7124eb039772b935f2244fbb73fc8ee65b9acf2375da1c07bf/python_jose-3.5.0.tar.gz", hash = "sha256:fb4eaa44dbeb1c26dcc69e4bd7ec54a1cb8dd64d3b4d81ef08d90ff453f2b01b", size = 92726, upload-time = "2025-05-28T17:31:54.288Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/c3/0bd11992072e6a1c513b16500a5d07f91a24017c5909b02c72c62d7ad024/python_jose-3.5.0-py2.py3-none-any.whl", hash = "sha256:abd1202f23d34dfad2c3d28cb8617b90acf34132c7afd60abd0b0b7d3cb55771", size = 34624, upload-time = "2025-05-28T17:31:52.802Z" },
-]
-
-[package.optional-dependencies]
-cryptography = [
-    { name = "cryptography" },
 ]
 
 [[package]]
@@ -1710,18 +1679,6 @@ wheels = [
 ]
 
 [[package]]
-name = "rsa"
-version = "4.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
-]
-
-[[package]]
 name = "simple-websocket"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1731,15 +1688,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b0/d4/bfa032f961103eba93de583b161f0e6a5b63cebb8f2c7d0c6e6efe1e3d2e/simple_websocket-1.1.0.tar.gz", hash = "sha256:7939234e7aa067c534abdab3a9ed933ec9ce4691b0713c78acb195560aa52ae4", size = 17300, upload-time = "2024-10-10T22:39:31.412Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/59/0782e51887ac6b07ffd1570e0364cf901ebc36345fea669969d2084baebb/simple_websocket-1.1.0-py3-none-any.whl", hash = "sha256:4af6069630a38ed6c561010f0e11a5bc0d4ca569b36306eb257cd9a192497c8c", size = 13842, upload-time = "2024-10-10T22:39:29.645Z" },
-]
-
-[[package]]
-name = "six"
-version = "1.17.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- replace python-jose with PyJWT while preserving the HS256 authentication boundary
- regenerate uv.lock without python-jose, ecdsa, rsa, pyasn1, or six
- remove the pip-audit exception for PYSEC-2026-1325
- retain compatibility with unexpired HS256 tokens issued before the library switch
- update dependency and architecture documentation

## Security evidence

- Dependabot alert: #38 / GHSA-wj6h-64fc-37mp / CVE-2024-23342
- Stable RED: 4c9bd2c2a8c80d459411a451988da11b8c592aed (same two failures across three runs)
- Fixed GREEN review SHA: 78e60c513f8cd3b906ed80085bc3b5733797ef3b
- Fixed-SHA two-axis review: Standards 0 findings; Spec 0 findings
- No Dependabot alert was dismissed

## Validation

- uv lock --check
- uv pip check: all installed packages are compatible
- pip-audit 2.10.1, no ignore: No known vulnerabilities found
- Ruff 0.15.22: passed
- fresh SQLite migration: a6c4d8e2f9b1 (head)
- targeted dependency/JWT tests: 8 passed
- full pytest: 532 passed

## Post-merge acceptance

After merge, verify Quality and update-uv-graph on the exact merge SHA, then read back Dependabot #38 as fixed and confirm SBOM no longer includes ecdsa/python-jose.